### PR TITLE
Alternative implementation

### DIFF
--- a/src/Data/ProtocolBuffers/Decode.hs
+++ b/src/Data/ProtocolBuffers/Decode.hs
@@ -41,7 +41,7 @@ decodeMessage = decode =<< HashMap.map reverse <$> go HashMap.empty where
   go msg = do
     mfield <- Just <$> getWireField <|> return Nothing
     case mfield of
-      Just v  -> go $! HashMap.insertWith (++) (wireFieldTag v) [v] msg
+      Just v  -> go $! HashMap.insertWith (\(x:[]) xs -> x:xs) (wireFieldTag v) [v] msg
       Nothing -> return msg
 
 -- |


### PR DESCRIPTION
Hi, this is what I meant by using cons. Arguably less readable, but slightly better garbage collection output:

Entirely up to you which one you select, this one avoids the HashMap.map reverse.

Before:

```
~/tmp/bench$ time ./burst +RTS -s
100000
      62,300,968 bytes allocated in the heap
      14,002,224 bytes copied during GC
       2,275,680 bytes maximum residency (6 sample(s))
         731,568 bytes maximum slop
               6 MB total memory in use (0 MB lost due to fragmentation)

                                    Tot time (elapsed)  Avg pause  Max pause
  Gen  0       115 colls,     0 par    0.01s    0.01s     0.0001s    0.0005s
  Gen  1         6 colls,     0 par    0.00s    0.00s     0.0007s    0.0019s

  INIT    time    0.00s  (  0.00s elapsed)
  MUT     time    0.02s  (  0.02s elapsed)
  GC      time    0.01s  (  0.01s elapsed)
  EXIT    time    0.00s  (  0.00s elapsed)
  Total   time    0.03s  (  0.03s elapsed)

  %GC     time      38.9%  (39.9% elapsed)

  Alloc rate    3,804,130,501 bytes per MUT second

  Productivity  60.8% of total user, 62.5% of total elapsed


real    0m0.030s
user    0m0.020s
sys 0m0.007s
```

After:

```
~/tmp/bench$ time ./burst +RTS -s
100000
      61,180,944 bytes allocated in the heap
      11,086,088 bytes copied during GC
       1,798,504 bytes maximum residency (6 sample(s))
         247,664 bytes maximum slop
               5 MB total memory in use (0 MB lost due to fragmentation)

                                    Tot time (elapsed)  Avg pause  Max pause
  Gen  0       112 colls,     0 par    0.01s    0.01s     0.0001s    0.0003s
  Gen  1         6 colls,     0 par    0.00s    0.00s     0.0008s    0.0018s

  INIT    time    0.00s  (  0.00s elapsed)
  MUT     time    0.02s  (  0.02s elapsed)
  GC      time    0.01s  (  0.01s elapsed)
  EXIT    time    0.00s  (  0.00s elapsed)
  Total   time    0.03s  (  0.03s elapsed)

  %GC     time      33.7%  (34.7% elapsed)

  Alloc rate    2,945,317,731 bytes per MUT second

  Productivity  66.0% of total user, 68.2% of total elapsed


real    0m0.034s
user    0m0.033s
sys 0m0.007s
```
