### PR TITLE
Improve performance by using binary

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Control.DeepSeq         (NFData)
+import Criterion.Main
+import Data.ProtocolBuffers
+import GHC.Generics(Generic)
+import Data.Binary.Builder.Sized
+import Data.Binary.Get
+import Data.ByteString(ByteString)
+import qualified Data.ByteString.Lazy as LBS
+
+data Burst = Burst {
+    frames :: Repeated 1 (Value ByteString)
+} deriving (Generic, Eq, Show)
+
+instance NFData Burst
+instance Encode Burst
+instance Decode Burst
+
+burst :: Int -> Burst
+burst = Burst . putField . flip replicate "abcd"
+
+encodeBurst :: Int -> LBS.ByteString
+encodeBurst = enc . burst
+
+enc :: Encode a => a -> LBS.ByteString
+enc = toLazyByteString . encodeMessage
+
+dec :: Decode a => LBS.ByteString -> a
+dec = runGet decodeMessage
+
+decBurst :: LBS.ByteString -> Burst
+decBurst = dec
+
+main :: IO ()
+main = defaultMain [
+  bgroup "encoding" [
+     bgroup "burst" [
+        bench "1" $ nf enc (burst 1),
+        bench "10" $ nf enc (burst 10),
+        bench "100" $ nf enc (burst 100),
+        bench "1000" $ nf enc (burst 1000)
+        ]
+     ],
+  bgroup "decoding" [
+     bgroup "burst" [
+        bench "1" $ nf decBurst (encodeBurst 1),
+        bench "10" $ nf decBurst (encodeBurst 10),
+        bench "100" $ nf decBurst (encodeBurst 100),
+        bench "1000" $ nf decBurst (encodeBurst 1000)
+        ]
+     ]
+  ]

--- a/bench/Data.hs
+++ b/bench/Data.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Data where
+
+import Control.DeepSeq         (NFData)
+import Data.ProtocolBuffers
+import GHC.Generics(Generic)
+import Data.Binary.Builder.Sized
+import Data.Binary.Get
+import Data.ByteString(ByteString)
+import qualified Data.ByteString.Lazy as LBS
+
+data Burst = Burst {
+    frames :: Repeated 1 (Value ByteString)
+} deriving (Generic, Eq, Show)
+
+instance NFData Burst
+instance Encode Burst
+instance Decode Burst
+
+burst :: Int -> Burst
+burst = Burst . putField . flip replicate "abcd"
+
+encodeBurst :: Int -> LBS.ByteString
+encodeBurst = enc . burst
+
+enc :: Encode a => a -> LBS.ByteString
+enc = toLazyByteString . encodeMessage
+
+dec :: Decode a => LBS.ByteString -> a
+dec = runGet decodeMessage
+
+decBurst :: LBS.ByteString -> Burst
+decBurst = dec

--- a/bench/Nested.hs
+++ b/bench/Nested.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Nested where
 
 import           Control.DeepSeq             (NFData)
@@ -25,12 +26,15 @@ instance (GEncode (K1 R (Required 2 v)), GEncode (K1 R (Required 1 k))) => Encod
 instance (GDecode (K1 R (Required 2 v)), GDecode (K1 R (Required 1 k))) => Decode (MapEntry k v) where
 instance (NFData k, NFData v) => NFData (MapEntry k v)
 
+deriving instance (Eq (Required 2 v), Eq (Required 1 k)) => Eq (MapEntry k v)
+deriving instance (Show (Required 2 v), Show (Required 1 k)) => Show (MapEntry k v)
+
 data A = A {
   _1 :: Required 1 (Value Float),
   _2 :: Required 2 (Value Float),
   _3 :: Required 3 (Value Float),
   _4 :: Required 4 (Value Float)
-  } deriving (Generic)
+  } deriving (Generic, Eq, Show)
 
 instance Encode A
 instance Decode A
@@ -38,7 +42,7 @@ instance NFData A
 
 data B = B {
   as :: Map 1 (Value Text) (Message A)
-} deriving (Generic)
+} deriving (Generic, Eq, Show)
 
 instance Encode B
 instance Decode B
@@ -46,7 +50,7 @@ instance NFData B
 
 data C = C {
   bs :: Map 1 (Value Text) (Message B)
-} deriving (Generic)
+} deriving (Generic, Eq, Show)
 
 instance Encode C
 instance Decode C

--- a/bench/Nested.hs
+++ b/bench/Nested.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Nested where
+
+import           Control.DeepSeq             (NFData)
+import qualified Data.ByteString.Lazy        as LBS
+import           Data.ProtocolBuffers
+import           Data.ProtocolBuffers.Internal
+import           Data.Text                   (Text, pack)
+import           GHC.Generics                (Generic, K1, R)
+
+import           Data
+
+data MapEntry k v = MapEntry {
+  key   :: Required 1 k,
+  value :: Required 2 v
+  } deriving (Generic)
+
+type Map n k v = Repeated n (Message (MapEntry k v))
+
+instance (GEncode (K1 R (Required 2 v)), GEncode (K1 R (Required 1 k))) => Encode (MapEntry k v) where
+instance (GDecode (K1 R (Required 2 v)), GDecode (K1 R (Required 1 k))) => Decode (MapEntry k v) where
+instance (NFData k, NFData v) => NFData (MapEntry k v)
+
+data A = A {
+  _1 :: Required 1 (Value Float),
+  _2 :: Required 2 (Value Float),
+  _3 :: Required 3 (Value Float),
+  _4 :: Required 4 (Value Float)
+  } deriving (Generic)
+
+instance Encode A
+instance Decode A
+instance NFData A
+
+data B = B {
+  as :: Map 1 (Value Text) (Message A)
+} deriving (Generic)
+
+instance Encode B
+instance Decode B
+instance NFData B
+
+data C = C {
+  bs :: Map 1 (Value Text) (Message B)
+} deriving (Generic)
+
+instance Encode C
+instance Decode C
+instance NFData C
+
+decNested :: LBS.ByteString -> C
+decNested = dec
+
+nested :: Int -> Int -> C
+nested i j = C (putField bs')
+  where
+    show' = pack . show
+    mkMap (k, v) = MapEntry (putField k) (putField v)
+    bs' = map mkMap $ zip (map show' [0..i]) $ replicate i b
+    b :: B
+    b = B $ putField $ map mkMap $ zip (map show' [0..j]) $ replicate j a
+    a :: A
+    a = A (putField 0.1) (putField 0.2) (putField 0.3) (putField 0.4)

--- a/plugin/Main.hs
+++ b/plugin/Main.hs
@@ -13,7 +13,7 @@ import Data.Int
 import Data.Monoid
 import Data.ProtocolBuffers
 import Data.ProtocolBuffers.Internal
-import Data.Serialize
+import Data.Binary
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TextL

--- a/protobuf.cabal
+++ b/protobuf.cabal
@@ -47,7 +47,7 @@ library
   build-depends:
     base                       >= 4.7 && < 5,
     bytestring                 >= 0.9,
-    cereal                     >= 0.3,
+    binary                     >= 0.7,
     data-binary-ieee754        >= 0.4,
     deepseq                    >= 1.1,
     mtl                        == 2.*,
@@ -89,7 +89,7 @@ test-suite protobuf-test
   build-depends:
     base                       >= 4.7 && < 5,
     bytestring,
-    cereal,
+    binary,
     containers,
     hex,
     mtl,

--- a/protobuf.cabal
+++ b/protobuf.cabal
@@ -37,6 +37,7 @@ library
     Data.ProtocolBuffers
     Data.ProtocolBuffers.Internal
     Data.ProtocolBuffers.Orphans
+    Data.Binary.Builder.Sized
   other-modules:
     Data.ProtocolBuffers.Decode
     Data.ProtocolBuffers.Encode

--- a/protobuf.cabal
+++ b/protobuf.cabal
@@ -104,6 +104,26 @@ test-suite protobuf-test
     HUnit                      >= 1.2,
     QuickCheck                 >= 2.4
 
+
+benchmark bench
+  type: exitcode-stdio-1.0
+  hs-source-dirs: bench
+  main-is: Bench.hs
+  build-depends:
+    base,
+    criterion,
+    deepseq,
+    bytestring,
+    binary,
+    containers,
+    hex,
+    mtl,
+    protobuf,
+    tagged,
+    text,
+    unordered-containers
+  ghc-options:   -O2
+
 source-repository head
   type:     git
   location: https://github.com/alphaHeavy/protobuf.git

--- a/src/Data/Binary/Builder/Sized.hs
+++ b/src/Data/Binary/Builder/Sized.hs
@@ -1,63 +1,52 @@
 module Data.Binary.Builder.Sized where
 
-import qualified Data.Binary.Builder as B
-import Data.Monoid (Sum(..), mempty, mappend)
+import qualified Data.ByteString.Builder as B
+import Data.Monoid (mempty, mappend, Monoid)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString as BS
 import qualified Data.Word as W
 
-type Builder = (Sum Int, B.Builder)
+data Builder = Builder {-# UNPACK #-} !Int B.Builder
+
+instance Monoid Builder where
+  mempty = Builder 0 mempty
+  (Builder i b) `mappend` (Builder i' b') = Builder (i + i') (mappend b b')
 
 toLazyByteString :: Builder -> LBS.ByteString
-toLazyByteString = B.toLazyByteString . snd
+toLazyByteString (Builder _ b) = B.toLazyByteString b
 
 size :: Builder -> Int
-size = getSum . fst
+size (Builder i _) = i
 
 empty :: Builder
 empty = mempty
 
 singleton :: W.Word8 -> Builder
-singleton = mk 1 . B.singleton
+singleton = Builder 1 . B.word8
 
 append :: Builder -> Builder -> Builder
 append = mappend
 
 fromByteString :: BS.ByteString -> Builder
-fromByteString s = (Sum $ BS.length s, B.fromByteString s)
+fromByteString s = Builder (BS.length s) $ B.byteString s
 
 fromLazyByteString :: LBS.ByteString -> Builder
-fromLazyByteString s = (Sum $ fromInteger $ toInteger $ LBS.length s, B.fromLazyByteString s)
-
-flush :: Builder
-flush = (Sum 0, B.flush)
-
-mk :: Int -> B.Builder -> Builder
-mk i f = (Sum i, f)
+fromLazyByteString s = Builder (fromInteger $ toInteger $ LBS.length s) $ B.lazyByteString s
 
 putWord16be :: W.Word16 -> Builder
-putWord16be = mk 2 . B.putWord16be
+putWord16be = Builder 2 . B.word16BE
 
 putWord32be :: W.Word32 -> Builder
-putWord32be = mk 4 . B.putWord32be
+putWord32be = Builder 4 . B.word32BE
 
 putWord64be :: W.Word64 -> Builder
-putWord64be = mk 8 . B.putWord64be
+putWord64be = Builder 8 . B.word64BE
 
 putWord16le :: W.Word16 -> Builder
-putWord16le = mk 2 . B.putWord16le
+putWord16le = Builder 2 . B.word16LE
 
 putWord32le :: W.Word32 -> Builder
-putWord32le = mk 4 . B.putWord32le
+putWord32le = Builder 4 . B.word32LE
 
 putWord64le :: W.Word64 -> Builder
-putWord64le = mk 8 . B.putWord64le
-
-putWord16host :: W.Word16 -> Builder
-putWord16host = mk 2 . B.putWord16host
-
-putWord32host :: W.Word32 -> Builder
-putWord32host = mk 4 . B.putWord32host
-
-putWord64host :: W.Word64 -> Builder
-putWord64host = mk 8 . B.putWord64host
+putWord64le = Builder 8 . B.word64LE

--- a/src/Data/Binary/Builder/Sized.hs
+++ b/src/Data/Binary/Builder/Sized.hs
@@ -31,7 +31,7 @@ fromByteString :: BS.ByteString -> Builder
 fromByteString s = Builder (BS.length s) $ B.byteString s
 
 fromLazyByteString :: LBS.ByteString -> Builder
-fromLazyByteString s = Builder (fromInteger $ toInteger $ LBS.length s) $ B.lazyByteString s
+fromLazyByteString s = Builder (fromIntegral $ LBS.length s) $ B.lazyByteString s
 
 putWord16be :: W.Word16 -> Builder
 putWord16be = Builder 2 . B.word16BE

--- a/src/Data/Binary/Builder/Sized.hs
+++ b/src/Data/Binary/Builder/Sized.hs
@@ -1,0 +1,63 @@
+module Data.Binary.Builder.Sized where
+
+import qualified Data.Binary.Builder as B
+import Data.Monoid (Sum(..), mempty, mappend)
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString as BS
+import qualified Data.Word as W
+
+type Builder = (Sum Int, B.Builder)
+
+toLazyByteString :: Builder -> LBS.ByteString
+toLazyByteString = B.toLazyByteString . snd
+
+size :: Builder -> Int
+size = getSum . fst
+
+empty :: Builder
+empty = mempty
+
+singleton :: W.Word8 -> Builder
+singleton = mk 1 . B.singleton
+
+append :: Builder -> Builder -> Builder
+append = mappend
+
+fromByteString :: BS.ByteString -> Builder
+fromByteString s = (Sum $ BS.length s, B.fromByteString s)
+
+fromLazyByteString :: LBS.ByteString -> Builder
+fromLazyByteString s = (Sum $ fromInteger $ toInteger $ LBS.length s, B.fromLazyByteString s)
+
+flush :: Builder
+flush = (Sum 0, B.flush)
+
+mk :: Int -> B.Builder -> Builder
+mk i f = (Sum i, f)
+
+putWord16be :: W.Word16 -> Builder
+putWord16be = mk 2 . B.putWord16be
+
+putWord32be :: W.Word32 -> Builder
+putWord32be = mk 4 . B.putWord32be
+
+putWord64be :: W.Word64 -> Builder
+putWord64be = mk 8 . B.putWord64be
+
+putWord16le :: W.Word16 -> Builder
+putWord16le = mk 2 . B.putWord16le
+
+putWord32le :: W.Word32 -> Builder
+putWord32le = mk 4 . B.putWord32le
+
+putWord64le :: W.Word64 -> Builder
+putWord64le = mk 8 . B.putWord64le
+
+putWord16host :: W.Word16 -> Builder
+putWord16host = mk 2 . B.putWord16host
+
+putWord32host :: W.Word32 -> Builder
+putWord32host = mk 4 . B.putWord32host
+
+putWord64host :: W.Word64 -> Builder
+putWord64host = mk 8 . B.putWord64host

--- a/src/Data/ProtocolBuffers.hs
+++ b/src/Data/ProtocolBuffers.hs
@@ -20,7 +20,7 @@
 --import "GHC.Generics" ('GHC.Generics.Generic')
 --import "GHC.TypeLits"
 --import "Data.Monoid"
---import "Data.Serialize"
+--import "Data.Binary"
 --import "Data.Hex"  -- cabal install hex (for testing)
 --
 -- data Foo = Foo
@@ -41,15 +41,15 @@
 --
 -- >>> let msg = Foo{field1 = putField 42, field2 = mempty, field3 = putField [True, False]}
 --
--- To serialize a message first convert it into a 'Data.Serialize.Put' by way of 'encodeMessage'
--- and then to a 'Data.ByteString.ByteString' by using 'Data.Serialize.runPut'. Lazy
--- 'Data.ByteString.Lazy.ByteString' serialization is done with 'Data.Serialize.runPutLazy'.
+-- To serialize a message first convert it into a 'Data.Binary.Put' by way of 'encodeMessage'
+-- and then to a 'Data.ByteString.ByteString' by using 'Data.Binary.runPut'. Lazy
+-- 'Data.ByteString.Lazy.ByteString' serialization is done with 'Data.Binary.runPutLazy'.
 --
 -- >>> fmap hex runPut $ encodeMessage msg
 -- "082A18011800"
 --
 -- Decoding is done with the inverse functions: 'decodeMessage'
--- and 'Data.Serialize.runGet', or 'Data.Serialize.runGetLazy'.
+-- and 'Data.Binary.runGet'.
 --
 -- >>> runGet decodeMessage =<< unhex "082A18011800" :: Either String Foo
 -- Right

--- a/src/Data/ProtocolBuffers/Encode.hs
+++ b/src/Data/ProtocolBuffers/Encode.hs
@@ -16,7 +16,8 @@ import Data.Foldable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Proxy
-import Data.Binary.Put
+import Data.Binary.Builder
+import Data.Monoid
 
 import GHC.Generics
 import GHC.TypeLits
@@ -27,44 +28,43 @@ import qualified Data.ByteString.Lazy as LBS
 
 -- |
 -- Encode a Protocol Buffers message.
-encodeMessage :: Encode a => a -> Put
+encodeMessage :: Encode a => a -> Builder
 encodeMessage = encode
 
 -- |
 -- Encode a Protocol Buffers message prefixed with a varint encoded 32-bit integer describing it's length.
-encodeLengthPrefixedMessage :: Encode a => a -> Put
+encodeLengthPrefixedMessage :: Encode a => a -> Builder
 {-# INLINE encodeLengthPrefixedMessage #-}
-encodeLengthPrefixedMessage msg = do
-  let msg' = runPut $ encodeMessage msg
-  putVarUInt $ LBS.length msg'
-  putLazyByteString msg'
+encodeLengthPrefixedMessage msg = (putVarUInt $ LBS.length msg') <> fromLazyByteString msg'
+  where
+    msg' = toLazyByteString $ encodeMessage msg
 
 class Encode (a :: *) where
-  encode :: a -> Put
-  default encode :: (Generic a, GEncode (Rep a)) => a -> Put
+  encode :: a -> Builder
+  default encode :: (Generic a, GEncode (Rep a)) => a -> Builder
   encode = gencode . from
 
 -- | Untyped message encoding
 instance Encode (HashMap Tag [WireField]) where
-  encode = traverse_ step . HashMap.toList where
-    step = uncurry (traverse_ . encodeWire)
+  encode = foldMap step . HashMap.toList where
+    step = uncurry (foldMap . encodeWire)
 
 class GEncode (f :: * -> *) where
-  gencode :: f a -> Put
+  gencode :: f a -> Builder
 
 instance GEncode a => GEncode (M1 i c a) where
   gencode = gencode . unM1
 
 instance (GEncode a, GEncode b) => GEncode (a :*: b) where
-  gencode (x :*: y) = gencode x >> gencode y
+  gencode (x :*: y) = gencode x <> gencode y
 
 instance (GEncode a, GEncode b) => GEncode (a :+: b) where
   gencode (L1 x) = gencode x
   gencode (R1 y) = gencode y
 
 instance (EncodeWire a, KnownNat n, Foldable f) => GEncode (K1 i (Field n (f a))) where
-  gencode = traverse_ (encodeWire tag) . runField . unK1 where
+  gencode = foldMap (encodeWire tag) . runField . unK1 where
     tag = fromIntegral $ natVal (Proxy :: Proxy n)
 
 instance GEncode U1 where
-  gencode _ = return ()
+  gencode _ = empty

--- a/src/Data/ProtocolBuffers/Encode.hs
+++ b/src/Data/ProtocolBuffers/Encode.hs
@@ -24,7 +24,6 @@ import GHC.TypeLits
 
 import Data.ProtocolBuffers.Types
 import Data.ProtocolBuffers.Wire
-import qualified Data.ByteString.Lazy as LBS
 
 -- |
 -- Encode a Protocol Buffers message.
@@ -35,9 +34,9 @@ encodeMessage = encode
 -- Encode a Protocol Buffers message prefixed with a varint encoded 32-bit integer describing it's length.
 encodeLengthPrefixedMessage :: Encode a => a -> Builder
 {-# INLINE encodeLengthPrefixedMessage #-}
-encodeLengthPrefixedMessage msg = (putVarUInt $ LBS.length msg') <> fromLazyByteString msg'
+encodeLengthPrefixedMessage msg = (putVarUInt $ size msg') <> msg'
   where
-    msg' = toLazyByteString $ encodeMessage msg
+    msg' = encodeMessage msg
 
 class Encode (a :: *) where
   encode :: a -> Builder

--- a/src/Data/ProtocolBuffers/Encode.hs
+++ b/src/Data/ProtocolBuffers/Encode.hs
@@ -12,18 +12,18 @@ module Data.ProtocolBuffers.Encode
   , GEncode
   ) where
 
-import qualified Data.ByteString as B
 import Data.Foldable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Proxy
-import Data.Serialize.Put
+import Data.Binary.Put
 
 import GHC.Generics
 import GHC.TypeLits
 
 import Data.ProtocolBuffers.Types
 import Data.ProtocolBuffers.Wire
+import qualified Data.ByteString.Lazy as LBS
 
 -- |
 -- Encode a Protocol Buffers message.
@@ -36,8 +36,8 @@ encodeLengthPrefixedMessage :: Encode a => a -> Put
 {-# INLINE encodeLengthPrefixedMessage #-}
 encodeLengthPrefixedMessage msg = do
   let msg' = runPut $ encodeMessage msg
-  putVarUInt $ B.length msg'
-  putByteString msg'
+  putVarUInt $ LBS.length msg'
+  putLazyByteString msg'
 
 class Encode (a :: *) where
   encode :: a -> Put

--- a/src/Data/ProtocolBuffers/Encode.hs
+++ b/src/Data/ProtocolBuffers/Encode.hs
@@ -16,7 +16,7 @@ import Data.Foldable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Proxy
-import Data.Binary.Builder
+import Data.Binary.Builder.Sized
 import Data.Monoid
 
 import GHC.Generics

--- a/src/Data/ProtocolBuffers/Message.hs
+++ b/src/Data/ProtocolBuffers/Message.hs
@@ -19,7 +19,6 @@ import Control.DeepSeq (NFData(..))
 import Data.Foldable
 import Data.Monoid
 import Data.Binary.Get
-import Data.Binary.Put
 import Data.Traversable
 
 import GHC.Generics

--- a/src/Data/ProtocolBuffers/Message.hs
+++ b/src/Data/ProtocolBuffers/Message.hs
@@ -157,8 +157,7 @@ type instance Optional n (Message a) = Field n (OptionalField (Maybe (Message a)
 type instance Required n (Message a) = Field n (RequiredField (Always (Message a)))
 
 instance (Foldable f, Encode m) => EncodeWire (f (Message m)) where
-  encodeWire t =
-    traverse_ (encodeWire t . runPut . encode . runMessage)
+  encodeWire t = foldMap (encodeWire t . encode . runMessage)
 
 instance Decode m => DecodeWire (Message m) where
   decodeWire (DelimitedField _ bs) = pure $ Message $ runGet decodeMessage $ LBS.fromStrict bs

--- a/src/Data/ProtocolBuffers/Wire.hs
+++ b/src/Data/ProtocolBuffers/Wire.hs
@@ -269,10 +269,10 @@ instance EncodeWire Builder where
   encodeWire t val = putWireTag t 2 <> putVarUInt (size val) <> val
 
 instance EncodeWire LBS.ByteString where
-  encodeWire t val = putWireTag t 2 <> putVarUInt (LBS.length val) <> fromLazyByteString val
+  encodeWire t val = encodeWire t $ fromLazyByteString val
 
 instance EncodeWire ByteString where
-  encodeWire t val = putWireTag t 2 <> putVarUInt (B.length val) <> fromByteString val
+  encodeWire t val = encodeWire t $ fromByteString val
 
 instance DecodeWire ByteString where
   decodeWire (DelimitedField _ bs) = pure bs
@@ -303,10 +303,9 @@ decodePackedList _ _ = empty
 -- Empty lists are not written out
 encodePackedList :: Tag -> Builder -> Builder
 {-# INLINE encodePackedList #-}
-encodePackedList t p
-  | bs <- toLazyByteString p
-  , not (LBS.null bs) = encodeWire t (LBS.toStrict bs)
-  | otherwise = mempty
+encodePackedList t p = case size p of
+  0 -> mempty
+  _ -> encodeWire t p
 
 instance EncodeWire (PackedList (Value Int32)) where
   encodeWire t (PackedList xs) =

--- a/src/Data/ProtocolBuffers/Wire.hs
+++ b/src/Data/ProtocolBuffers/Wire.hs
@@ -35,7 +35,7 @@ import Data.Int
 import Data.Monoid
 import Data.Binary.Get
 import qualified Data.Binary.IEEE754 as F
-import Data.Binary.Builder hiding (empty)
+import Data.Binary.Builder.Sized hiding (empty)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.Typeable
@@ -266,7 +266,7 @@ instance DecodeWire Double where
   decodeWire _ = empty
 
 instance EncodeWire Builder where
-  encodeWire t val = encodeWire t $ toLazyByteString val
+  encodeWire t val = putWireTag t 2 <> putVarUInt (size val) <> val
 
 instance EncodeWire LBS.ByteString where
   encodeWire t val = putWireTag t 2 <> putVarUInt (LBS.length val) <> fromLazyByteString val

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -37,7 +37,7 @@ import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
 import Data.Monoid
 import Data.Binary.Get (Get, runGet)
-import Data.Binary.Builder (Builder, toLazyByteString)
+import Data.Binary.Builder.Sized (Builder, toLazyByteString)
 import Data.Proxy
 import Data.Text (Text)
 import Data.Typeable


### PR DESCRIPTION

This pull request is backwards incompatible, but by using `binary`'s `Get` and a custom `Builder`, we can get an average 3-5x better performance, with some cases being 10x+. I don't know if this is a path you'd consider, but wanted to let you know about it.

We were experimenting with using protobuf instead of aeson for encoding one of our data types, and found that it was taking longer for both encoding and decoding. A simplified version of this data type is in `bench/Nested.hs`.

A quick change to use `binary` instead of `cereal` improved the decode speed, but neither `Data.Binary.Put` nor `Data.Binary.Builder` was that much faster.

Profiling revealed that encoding Messages was expensive, because we'd need to encode the message fully, calculate the length, and then write both. If we're using the `Builder` interface, with it's `Monoid` instance to build results, then we can memoize the length of the resulting `ByteString` during construction by using a type `(Sum, Builder)`. Because every type we serialize in a protobuf either has a statically known length, or is length prefixed, this adds a minor amount of calculation in the worst case, but a nice improvement in the best case. A version of this builder is included under `src/Data/Binary/Builder/Sized.hs`

I've added benchmarks for this branch, with corresponding benchmarks for master in https://github.com/joshbohde/protobuf/tree/benchmark .  They include the `Burst` data type from #4, as well. Results run on my laptop are here: https://gist.github.com/joshbohde/2b7b763805ddb2c6bfd1. Here they are in a table:


    benchmark              master    binary    pct change  throughput increase
    burst/encoding/1       2.648 μs  520.7 ns  -80.34      4.09
    burst/encoding/10      17.06 μs  2.995 μs  -82.44      4.7
    burst/encoding/100     155.3 μs  26.99 μs  -82.62      4.75
    burst/encoding/1000    1.702 ms  377.4 μs  -77.83      3.51
    burst/decoding/1       3.501 μs  759.1 ns  -78.32      3.61
    burst/decoding/10      22.46 μs  3.374 μs  -84.98      5.66
    burst/decoding/100     191.3 μs  29.81 μs  -84.42      5.42
    burst/decoding/1000    2.028 ms  414.0 μs  -79.59      3.9
    nested/encoding/a1     26.53 μs  2.414 μs  -90.9       9.99
    nested/encoding/a10    189.3 μs  14.50 μs  -92.34      12.06
    nested/encoding/a100   1.660 ms  155.7 μs  -90.62      9.66
    nested/encoding/a1000  15.82 ms  3.731 ms  -76.42      3.24
    nested/encoding/b10    271.1 μs  20.49 μs  -92.44      12.23
    nested/encoding/b100   2.524 ms  264.2 μs  -89.53      8.55
    nested/encoding/b1000  25.74 ms  5.751 ms  -77.66      3.48
    nested/decoding/a1     35.99 μs  1.011 μs  -97.19      34.6
    nested/decoding/a10    244.2 μs  1.071 μs  -99.56      227.0
    nested/decoding/a100   2.438 ms  1.079 μs  -99.96      2258.5
    nested/decoding/a1000  24.89 ms  3.765 μs  -99.98      6609.89
    nested/decoding/b10    353.8 μs  3.705 μs  -98.95      94.49
    nested/decoding/b100   3.666 ms  29.94 μs  -99.18      121.4
    nested/decoding/b1000  37.96 ms  446.8 μs  -98.82      83.96

I'm suspicious of some of these numbers, but can't find anything obviously wrong with the benchmarks.

Internally, we're seeing about a 100x speedup in decoding, and a 10x speedup in encoding of real data using this branch.
