### PR TITLE
Import orphan Foldable Last instance from base-orphans

### DIFF
--- a/protobuf.cabal
+++ b/protobuf.cabal
@@ -47,6 +47,7 @@ library
     Data.ProtocolBuffers.Wire
   build-depends:
     base                       >= 4.7 && < 5,
+    base-orphans               >= 0.5,
     bytestring                 >= 0.9,
     binary                     >= 0.7,
     data-binary-ieee754        >= 0.4,

--- a/src/Data/ProtocolBuffers/Orphans.hs
+++ b/src/Data/ProtocolBuffers/Orphans.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 -- |
 -- Messages containing 'Optional' 'Enumeration' fields fail to encode.
 -- This module contains orphan instances required to make these functional.
@@ -11,7 +7,4 @@
 
 module Data.ProtocolBuffers.Orphans (Foldable) where
 
-import Data.Foldable (Foldable)
-import Data.Monoid (Last(..))
-
-deriving instance Foldable Last
+import Data.Orphans ()

--- a/src/Data/ProtocolBuffers/Orphans.hs
+++ b/src/Data/ProtocolBuffers/Orphans.hs
@@ -5,6 +5,6 @@
 -- For more information reference the associated ticket:
 -- <https://github.com/alphaHeavy/protobuf/issues/3>
 
-module Data.ProtocolBuffers.Orphans (Foldable) where
+module Data.ProtocolBuffers.Orphans () where
 
 import Data.Orphans ()


### PR DESCRIPTION
GHC 8.0/`base-4.9` adds a `Foldable Last` instance, which conflicts with the orphan instance defined in `protobuf`. This commit consolidates the orphan `Foldable Last` instance with the one in `base-orphans` so that on GHC 7.10 and earlier, it uses the instance from `base-orphans`, and on GHC 8.0 and later, it uses the one defined in `base`.

Note that now `Data.ProtocolBuffers.Orphans` is simply a reexport of `Data.Orphans`, but I kept it to avoid a breaking API change.