### PR TITLE
Fix failure when decoding empty [packed] fields

### DIFF
--- a/src/Data/ProtocolBuffers/Decode.hs
+++ b/src/Data/ProtocolBuffers/Decode.hs
@@ -120,7 +120,7 @@ instance (DecodeWire a, KnownNat n) => GDecode (K1 i (Field n (RequiredField (Al
   gdecode msg = fieldDecode Required msg
 
 instance (DecodeWire (PackedList a), KnownNat n) => GDecode (K1 i (Packed n a)) where
-  gdecode msg = fieldDecode PackedField msg
+  gdecode msg = fieldDecode PackedField msg <|> pure (K1 mempty)
 
 instance GDecode U1 where
   gdecode _ = return U1

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -71,6 +71,7 @@ tests = testGroup "Root"
   , testCase "Google Reference Test2" test2
   , testCase "Google Reference Test3" test3
   , testCase "Google Reference Test4" test4
+  , testCase "Packed empty fields" test4_empty
   , testCase "Optional Enum Test5: Nothing" test5
   , testCase "Optional Enum Test5: Just Test5A" test6
   , testCase "Optional Enum Test5: Just Test5B" test7
@@ -451,6 +452,10 @@ instance Decode Test4
 test4 :: Assertion
 test4 = testSpecific msg =<< unhex "2206038e029ea705" where
   msg = Test4{test4_d = putField [3,270,86942]}
+
+test4_empty :: Assertion
+test4_empty = testSpecific msg =<< unhex "" where
+  msg = Test4{test4_d = putField mempty}
 
 data Test5Enum = Test5A | Test5B deriving (Eq, Show, Enum)
 data Test5 = Test5{test5_e :: Optional 5 (Enumeration Test5Enum)} deriving (Generic, Eq, Show)


### PR DESCRIPTION
Curently if message contains [packed=true] empty fields decodeMessage will fail with "Data.Binary.Get(Alternative).empty"
